### PR TITLE
Add video bg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1127,8 +1127,7 @@
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-      "dev": true
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1452,7 +1451,6 @@
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
       "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1469,8 +1467,7 @@
     "ajv-keywords": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.1.tgz",
-      "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==",
-      "dev": true
+      "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -1808,8 +1805,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -3150,8 +3146,7 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -3588,14 +3583,12 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -4799,8 +4792,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4818,7 +4810,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -5136,14 +5127,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -5181,8 +5170,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -6192,8 +6180,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -6910,7 +6897,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
       "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.4",
         "ajv": "^6.12.2",
@@ -8057,7 +8043,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -8083,6 +8068,28 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
+        }
+      }
+    },
+    "url-loader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
+      "integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "mime-types": "^2.1.26",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2821,6 +2821,11 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -4884,6 +4889,11 @@
         }
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -5032,6 +5042,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -6295,6 +6310,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6323,6 +6343,18 @@
         "prop-types": "^15.7.2",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
+      }
+    },
+    "react-player": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.6.0.tgz",
+      "integrity": "sha512-RLzAnHO00ZA5VnAZX6A6SGfCKQLOEcBGOM4POWAQkugh0VY2HjWUOYbHVt/7xeogyK3E1fP9dOxoPyLv8lBZ/A==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
       }
     },
     "react-promise-suspense": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "style-loader": "1.2.1",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.12",
-    "webpack-dev-server": "3.11.0"
+    "webpack-dev-server": "3.11.0",
+    "url-loader": "4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "16.13.1",
     "react-bootstrap": "1.3.0",
     "react-dom": "16.13.1",
+    "react-player": "^2.6.0",
     "react-router-dom": "5.2.0",
     "react-spring": "8.0.27",
     "react-three-fiber": "4.2.18",

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -9,3 +9,9 @@ body {
   min-width: 100vw;
   min-height: 100vh;
 }
+
+.mv-wrapper {
+  position: absolute;
+  width: 100vw;
+  opacity: 0.8;
+}

--- a/src/assets/styles/music.scss
+++ b/src/assets/styles/music.scss
@@ -1,15 +1,16 @@
 .music-container {
-  background-image: url('../musician-349790_1920.jpg');
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .album-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding-top: 10em;
-  padding-left: 30em;
-
+  justify-content: flex-end;
+  height: 100%;
+  padding-bottom: 5em;
+  margin-left: 5em;
   .album-block {
     display: flex;
     align-items: center;

--- a/src/assets/styles/shared.scss
+++ b/src/assets/styles/shared.scss
@@ -9,6 +9,7 @@
 
 .page-title {
   display: flex;
+  position: relative;
   align-items: flex-start;
   font-size: 50px;
   color: #ffffff;

--- a/src/component/Layout.js
+++ b/src/component/Layout.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Navbar from './Navbar';
-import Home from './Home';
 
 const Layout = ({ component }) => (
   <div className="layout-container">

--- a/src/component/Music.js
+++ b/src/component/Music.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Image, Row, Col, Container } from 'react-bootstrap';
 import darwinAlbum from '../assets/darwin.jpg';
-import youtubeIcon from '../assets/youtube.png';
-import CONSTANTS from '../utils/constants';
 
 const Music = () => {
   return (
-    <div className="page-container music-container">
+    <div className="music-container">
       <span className="page-title">Music</span>
       <Container className="album-container">
         <Row>
@@ -15,12 +13,7 @@ const Music = () => {
             <div className="album-text-block">
               <span className="album-title">⍺- Single</span>
               <ul>
-                <li>
-                  1. Eagle Eye
-                  <a target="_blank" href={CONSTANTS.LINKS.EAGLE_EYE}>
-                    <Image src={youtubeIcon} />
-                  </a>
-                </li>
+                <li>1. Eagle Eye</li>
                 <li>2. Fire And Ice</li>
               </ul>
             </div>

--- a/src/component/MusicLayout.js
+++ b/src/component/MusicLayout.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactPlayer from 'react-player';
+import Navbar from './Navbar';
+import drumVideo from '../assets/video/profile_low2.mp4';
+
+const MusicLayout = ({ component }) => {
+  return (
+    <div className="layout-container">
+      <video autoPlay muted loop className="mv-wrapper">
+        <source src={drumVideo} type="video/mp4" />
+      </video>
+      <Navbar />
+      {component}
+    </div>
+  );
+};
+
+export default MusicLayout;

--- a/src/component/Router.js
+++ b/src/component/Router.js
@@ -5,10 +5,11 @@ import Home from '../component/Home';
 import Music from '../component/Music';
 import Profile from '../component/Profile';
 import Scene1 from './canvas/components/scene1';
+import MusicLayout from './MusicLayout';
 
 const MainRoute = () => {
   const homeComponent = () => <Layout component={<Home />} />;
-  const musicComponent = () => <Layout component={<Music />} />;
+  const musicComponent = () => <MusicLayout component={<Music />} />;
   const profileComponent = () => <Layout component={<Profile />} />;
   const canvasCompA = () => <Layout component={<Scene1 />} />;
   return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,10 @@ module.exports = {
         test: /\.(png|svg|jpg|gif|ttf)$/,
         use: ['file-loader'],
       },
+      {
+        test: /\.mp4$/,
+        use: ['url-loader'],
+      },
     ],
   },
   devServer: {


### PR DESCRIPTION
## General
Added `video` to play music introduction video as background.

## Technical
Added `react-player` due to have a plan to play video's uploaded to social media, but shifted to play video locally with `video` tag because there is no way to remove icons without premium.
However, the size of video in local is over 20MB and better shift to use uploaded one with subscriptions in future.